### PR TITLE
chore: Temporary disable tag alert actions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,20 +14,20 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
           git fetch --no-tags --prune --depth=1 origin +refs/heads/master:refs/remotes/origin/master
-      - uses: actions/github-script@v1
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            const path = require('path')
-            const { isUsingAlertBlock } = require(path.resolve(process.cwd(), 'scripts/tag-alert-blocks.js'))
+      # - uses: actions/github-script@v1
+      #   with:
+      #     github-token: ${{secrets.GITHUB_TOKEN}}
+      #     script: |
+      #       const path = require('path')
+      #       const { isUsingAlertBlock } = require(path.resolve(process.cwd(), 'scripts/tag-alert-blocks.js'))
 
-            isUsingAlertBlock().then(ok => {
-              if (ok) {
-                github.issues.addLabels({
-                  issue_number: context.issue.number,
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  labels: ['review-alert-box']
-                })
-              }
-            })
+      #       isUsingAlertBlock().then(ok => {
+      #         if (ok) {
+      #           github.issues.addLabels({
+      #             issue_number: context.issue.number,
+      #             owner: context.repo.owner,
+      #             repo: context.repo.repo,
+      #             labels: ['review-alert-box']
+      #           })
+      #         }
+      #       })


### PR DESCRIPTION
## Description of Problem

- `secrets.GITHUB_TOKEN` は固定化されたトークンであり、その PR 発行者の GitHub のトークンを利用する
  - そのため権限のないユーザーからの PR については、適切にラベルを付与する処理ができない

## Proposed Solution

- 暫定的対処として、現状存在が特に必要ない処理を STOP する
  - `JA_GITHUB_TOKEN` を用意し、 @potato4d の個人アカウントを紐付ける事も考えたが、アクセスコントロールを狭めることができないためセキュリティ上難しい

## Additional Information

- @vuejs-jp-bot でトークンを発行する手段はあるが、その場合該当 Bot がそのトークンにてアクセスできる範囲を最小化することが必要となる（public repo へのアクセスくらいの粒度しかできないので、難しそう）