### PR TITLE
chore(CI): Add upstream sync script

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -1,0 +1,33 @@
+name: todo
+
+on:
+  schedule:
+    - cron: 0 0 * * *
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          ref: master
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Add upstream
+        run: |
+          git add remote upstream git@github.com:vuejs/docs-next.git
+      - name: Pull upstream changes
+        run: |
+          git add remote upstream git@github.com:vuejs/docs-next.git
+      - name: Sync it
+        run: |
+          git push origin master
+

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -13,7 +13,7 @@ jobs:
         node-version: [12.x]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           ref: master
       - name: Use Node.js ${{ matrix.node-version }}
@@ -30,4 +30,3 @@ jobs:
       - name: Sync it
         run: |
           git push origin master
-


### PR DESCRIPTION
## Description of Problem

本家の内容を一度に取り込んでしまいたいが、 #150 の方針を取るために定期的に本家の内容を master に反映しておき、 lang-ja -> master への rebase のサイズ感を確認したい。

手動でやっても良いが、忘れかねない。

## Proposed Solution

定期的に master の内容を更新する GitHub Actions を用意した。

## Additional Information

GitHub Actions の cron は only running at default branch なので、コードにミスはあるかもしれない
