### PR TITLE
docs(example): Translate examples

### DIFF
--- a/src/examples/commits.md
+++ b/src/examples/commits.md
@@ -1,6 +1,6 @@
-# GitHub Commits
+# GitHub コミット
 
-> This example fetches latest Vue.js commits data from GitHub’s API and displays them as a list. You can switch between the master and dev branches.
+> この例は最新の Vue.js コミットデータを GitHub API から取得し、そしてそれらをリストとして表示します。あなたは master ブランチと dev ブランチ間を切り替えることができます。
 
 <p class="codepen" data-height="300" data-theme-id="39028" data-default-tab="js,result" data-user="Vue" data-slug-hash="RwaWmzY" data-preview="true" data-editable="true" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Commits">
   <span>See the Pen <a href="https://codepen.io/team/Vue/pen/RwaWmzY">

--- a/src/examples/elastic-header.md
+++ b/src/examples/elastic-header.md
@@ -1,4 +1,4 @@
-# Elastic Header Example
+# 弾力のあるヘッダ
 
 <p class="codepen" data-height="474" data-theme-id="39028" data-default-tab="js,result" data-user="immarina" data-slug-hash="ZEWGmar" style="height: 474px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Markdown Editor">
   <span>See the Pen <a href="https://codepen.io/immarina/pen/ZEWGmar">

--- a/src/examples/grid-component.md
+++ b/src/examples/grid-component.md
@@ -1,6 +1,6 @@
-# Grid Component
+# グリッドコンポーネント
 
-> This is an example of creating a reusable grid component and using it with external data.
+> これは再利用可能なグリッドコンポーネントを作成して外部データでそれを利用した例です。
 
 <p class="codepen" data-height="300" data-theme-id="39028" data-default-tab="js,result" data-user="Vue" data-slug-hash="zYqvQgw" data-preview="true" data-editable="true" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Elastic Draggable Header Example">
   <span>See the Pen <a href="https://codepen.io/team/Vue/pen/zYqvQgw">

--- a/src/examples/markdown.md
+++ b/src/examples/markdown.md
@@ -1,6 +1,6 @@
-# Markdown Editor
+# Markdown エディタ
 
-> A simple Markdown editor
+> すごくシンプルな Markdown エディタ。
 
 <p class="codepen" data-height="474" data-theme-id="39028" data-default-tab="js,result" data-user="immarina" data-slug-hash="oNxXzyB" style="height: 474px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Markdown Editor">
   <span>See the Pen <a href="https://codepen.io/immarina/pen/oNxXzyB">

--- a/src/examples/modal.md
+++ b/src/examples/modal.md
@@ -1,6 +1,6 @@
-# Modal Component
+# モーダルコンポーネント
 
-> Features used: component, prop passing, content insertion, transitions.
+> コンポーネント、プロパティの伝達、コンテンツ挿入、トランジションの機能が使われています。
 
 <p class="codepen" data-height="300" data-theme-id="39028" data-default-tab="css,result" data-user="Vue" data-slug-hash="BaKoeXe" data-preview="true" data-editable="true" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Markdown Editor">
   <span>See the Pen <a href="https://codepen.io/team/Vue/pen/BaKoeXe">

--- a/src/examples/select2.md
+++ b/src/examples/select2.md
@@ -1,6 +1,6 @@
-# Wrapper Component Example
+# ラッパーコンポーネント
 
-> In this example we are integrating a 3rd party jQuery plugin (select2) by wrapping it inside a custom component.
+> この例では、カスタムコンポーネント内部でラップすることによって、サードパーティの jQuery プラグイン (select2) を統合しています。
 
 <p class="codepen" data-height="300" data-theme-id="39028" data-default-tab="js,result" data-user="Vue" data-slug-hash="eYZpwOB" data-preview="true" data-editable="true" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Wrapper Component Example">
   <span>See the Pen <a href="https://codepen.io/team/Vue/pen/eYZpwOB">

--- a/src/examples/svg.md
+++ b/src/examples/svg.md
@@ -1,6 +1,6 @@
-# SVG Graph
+# SVG グラフ
 
-> This example showcases a combination of custom component, computed property, two-way binding and SVG support.
+> この例はカスタムコンポーネントの組み合わせ、算出プロパティ、双方向バインディング、そして SVG 対応を紹介します。
 
 <p class="codepen" data-height="300" data-theme-id="39028" data-default-tab="js,result" data-user="Vue" data-slug-hash="XWdmLWM" data-preview="true" data-editable="true" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 SVG Graph Example">
   <span>See the Pen <a href="https://codepen.io/team/Vue/pen/XWdmLWM">

--- a/src/examples/todomvc.md
+++ b/src/examples/todomvc.md
@@ -1,11 +1,11 @@
 # TodoMVC
 
-> This is a fully spec-compliant TodoMVC implementation in under 120 effective lines of JavaScript (excluding comments and blank lines).
+> これは Javascript の実質 120 行を切る(コメントと空行を除く)完全に仕様に準拠する TodoMVC 実装です。
 
 :::warning
-Note that if your web browser is configured to block 3rd-party data/cookies, the example below will not work, as the **localStorage** data will fail to be saved.
+あなたの Web ブラウザで 3rd-party データ/クッキーをブロックするよう設定している場合、localeStorage データの保存に失敗するため、以下の example は動作しない可能性があります。
 
-Additionally, due to limitations on CodePen, hashtag navigation will not work.
+さらに、 CodePen の制約によってハッシュナビゲーションは動作しません。
 :::
 
 <p class="codepen" data-height="300" data-theme-id="39028" data-default-tab="js,result" data-user="Vue" data-slug-hash="Yzqyozj" data-preview="true" data-editable="true" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 TodoMVC">

--- a/src/examples/tree-view.md
+++ b/src/examples/tree-view.md
@@ -1,6 +1,6 @@
-# Tree View
+# ツリー表示
 
-> Example of a tree view implementation showcasing recursive usage of components.
+> コンポーネントの再帰的な利用を紹介するシンプルなツリー表示実装の例。
 
 <p class="codepen" data-height="300" data-theme-id="39028" data-default-tab="js,result" data-user="Vue" data-slug-hash="WNwQqbN" data-preview="true" data-editable="true" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Tree View">
   <span>See the Pen <a href="https://codepen.io/team/Vue/pen/WNwQqbN">


### PR DESCRIPTION
Example セクションのタイトルとコンテンツの翻訳

## Note

基本的には Vue 2.x から要素が一部オミットされている状態なのでそのまま訳を移行しつつ、 Codesandbox の言及が CodePen に変わっている部分などについて細かな追従を行いました。