### PR TITLE
fix カスタムイベントページの原文残りを削除した

### DIFF
--- a/src/guide/component-custom-events.md
+++ b/src/guide/component-custom-events.md
@@ -141,8 +141,6 @@ app.component('user-name', {
 
 ## `v-model` 修飾子の処理
 
-When we were learning about form input bindings, we saw that `v-model` has [built-in modifiers](/guide/forms.html#modifiers) - `.trim`, `.number` and `.lazy`. In some cases, however, you might also want to add your own custom modifiers.
-
 フォーム入力バインディングについて学習していたときに、 `v-model`に [組み込み修飾子](/guide/forms.html#modifiers) -`.trim` 、 `.number` 、および `.lazy` があることがわかりました。ただし、場合によっては、独自のカスタム修飾子を追加することもできます。
 
 `v-model` バインディングによって提供される文字列の最初の文字を大文字にするカスタム修飾子の例、`capitalize`を作成してみましょう。


### PR DESCRIPTION
## Description of Problem
カスタムイベントページに原文残りを発見しました

## Proposed Solution
原文残りを削除しました

## Additional Information
公開ページでの該当箇所
https://v3.ja.vuejs.org/guide/component-custom-events.html#v-model-修飾子の処理:~:text=When%20we%20were%20learning%20about%20form,%2D.trim%20%E3%80%81%20.number%20%E3%80%81%E3%81%8A%E3%82%88%E3%81%B3%20.lazy%20%E3%81%8C%E3%81%82%E3%82%8B%E3%81%93%E3%81%A8%E3%81%8C%E3%82%8F%E3%81%8B%E3%82%8A%E3%81%BE%E3%81%97%E3%81%9F%E3%80%82%E3%81%9F%E3%81%A0%E3%81%97%E3%80%81%E5%A0%B4%E5%90%88%E3%81%AB%E3%82%88%E3%81%A3%E3%81%A6%E3%81%AF%E3%80%81%E7%8B%AC%E8%87%AA%E3%81%AE%E3%82%AB%E3%82%B9%E3%82%BF%E3%83%A0%E4%BF%AE%E9%A3%BE%E5%AD%90%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%99%E3%82%8B%E3%81%93%E3%81%A8%E3%82%82%E3%81%A7%E3%81%8D%E3%81%BE%E3%81%99%E3%80%82