### PR TITLE
refact strongの意味づけを「ない」から「要素を含まない」に修正した

### DIFF
--- a/src/guide/component-slots.md
+++ b/src/guide/component-slots.md
@@ -52,7 +52,7 @@ Vue には [Web Components spec draft](https://github.com/w3c/webcomponents/blob
 </todo-button>
 ```
 
-もしも `<todo-button>` のテンプレートが `<slot>` 要素を含ま **ない** 場合、開始タグと終了タグの間にある任意のコンテンツは破棄されます。
+もしも `<todo-button>` のテンプレートが `<slot>` **要素を含まない** 場合、開始タグと終了タグの間にある任意のコンテンツは破棄されます。
 
 ```html
 <!-- todo-button コンポーネントのテンプレート -->


### PR DESCRIPTION
## Description of Problem
`**ない**` ですと、内容がない意味づけと考えます

## Proposed Solution
`**要素を含まない**` にすると、内容のある意味づけとなり改善します

## Additional Information
公式ページでの該当箇所
https://v3.ja.vuejs.org/guide/component-slots.html#スロットコンテンツ:~:text=%E8%A6%81%E7%B4%A0%E3%82%92%E5%90%AB%E3%81%BE-,%E3%81%AA%E3%81%84
