### PR TITLE
refact composition APIの文章を改善した

### DIFF
--- a/src/guide/composition-api-setup.md
+++ b/src/guide/composition-api-setup.md
@@ -31,7 +31,7 @@ export default {
 ```
 
 :::warning
-しかし、`props` はリアクティブなので、props のリアクティブを削除してしまうため、**ES6 の分割代入を使うことができません。**
+しかし、`props` はリアクティブなので、**ES6 の分割代入を使うことができません。** props のリアクティブを削除してしまうからです。
 :::
 
 もし、props を分割代入する必要がある場合は、`setup` 関数内で [toRefs](reactivity-fundamentals.html#destructuring-reactive-state) を使うことによって安全に分割代入を行うことができます。


### PR DESCRIPTION
## Description of Problem
>-`props` はリアクティブなので、props のリアクティブを削除してしまうため、**ES6 の分割代入を使うことができません。**
「リアクティブだから、props のリアクティブを削除してしまう」というように受け取れてしまいます。

原文でも、次のように先に結論を述べた後で、
>because props are reactive, you cannot use ES6 destructuring 

次のように根拠を説明しています。
>because it will remove props reactivity.

## Proposed Solution
原文に沿った説明になるように修正しました。

## Additional Information
ja: https://v3.ja.vuejs.org/guide/composition-api-setup.html#プロパティ:~:text=%E3%81%97%E3%81%8B%E3%81%97%E3%80%81props%20%E3%81%AF%E3%83%AA%E3%82%A2%E3%82%AF%E3%83%86%E3%82%A3%E3%83%96%E3%81%AA%E3%81%AE%E3%81%A7%E3%80%81props%20%E3%81%AE%E3%83%AA%E3%82%A2%E3%82%AF%E3%83%86%E3%82%A3%E3%83%96%E3%82%92%E5%89%8A%E9%99%A4%E3%81%97%E3%81%A6%E3%81%97%E3%81%BE%E3%81%86%E3%81%9F%E3%82%81%E3%80%81ES6%20%E3%81%AE%E5%88%86%E5%89%B2%E4%BB%A3%E5%85%A5%E3%82%92%E4%BD%BF%E3%81%86%E3%81%93%E3%81%A8%E3%81%8C%E3%81%A7%E3%81%8D%E3%81%BE%E3%81%9B%E3%82%93%E3%80%82
en: https://v3.vuejs.org/guide/composition-api-setup.html#props:~:text=However%2C%20because%20props%20are%20reactive%2C%20you,because%20it%20will%20remove%20props%20reactivity.