### PR TITLE
サンプルで使われているタブを2スペースにしました(Composition APIのセットアップページ)

### DIFF
--- a/src/guide/composition-api-setup.md
+++ b/src/guide/composition-api-setup.md
@@ -42,9 +42,9 @@ export default {
 import { toRefs } from 'vue'
 
 setup(props) {
-	const { title } = toRefs(props)
+  const { title } = toRefs(props)
 
-	console.log(title.value)
+  console.log(title.value)
 }
 ```
 


### PR DESCRIPTION
## Description of Problem
表題の通りです

原文の方は先程PRが取り込まれました
https://github.com/vuejs/docs-next/pull/858

## Proposed Solution

## Additional Information
実ページでの該当箇所
https://v3.ja.vuejs.org/guide/composition-api-setup.html#プロパティ:~:text=const%20%7B%20title%20%7D%20%3D%20toRefs(props),console.log(title.value)