### PR TITLE
「初期化にtrueに設定」 を 「初期化でtrueに設定」に変更した(アプリケーション構成ページ)

### DIFF
--- a/src/api/application-config.md
+++ b/src/api/application-config.md
@@ -146,4 +146,4 @@ app.mixin({
 
 - **使用方法**:
 
-コンポーネントの初期化に `true` に設定することで、ブラウザの devtool 内の performance/timeline パネルにて、レンダリングおよびパッチにおけるパフォーマンスの追跡が可能となります。development モード並びに[performance.mark](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark) API が有効なブラウザでのみ機能します。
+コンポーネントの初期化で `true` に設定することで、ブラウザの devtool 内の performance/timeline パネルにて、レンダリングおよびパッチにおけるパフォーマンスの追跡が可能となります。development モード並びに[performance.mark](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark) API が有効なブラウザでのみ機能します。


### PR DESCRIPTION
## Description of Problem
「AにBに設定」という文に違和感があります

## Proposed Solution
「AをBに設定」という文への変更を提案します

## Additional Information
ja: https://v3.ja.vuejs.org/api/application-config.html#performance:~:text=%E3%82%B3%E3%83%B3%E3%83%9D%E3%83%BC%E3%83%8D%E3%83%B3%E3%83%88%E3%81%AE%E5%88%9D%E6%9C%9F%E5%8C%96%E3%81%AB%20true%20%E3%81%AB%E8%A8%AD%E5%AE%9A%E3%81%99%E3%82%8B
en: https://v3.vuejs.org/api/application-config.html#performance:~:text=Set%20this%20to%20true%20to%20enable%20component%20init