### PR TITLE
Migration > Array Refs の翻訳を追従

### DIFF
--- a/src/guide/migration/array-refs.md
+++ b/src/guide/migration/array-refs.md
@@ -25,7 +25,9 @@ export default {
   },
   methods: {
     setItemRef(el) {
-      this.itemRefs.push(el)
+      if (el) {
+        this.itemRefs.push(el)
+      }
     }
   },
   beforeUpdate() {
@@ -40,13 +42,15 @@ export default {
 コンポジション API を使う場合
 
 ```js
-import { ref, onBeforeUpdate, onUpdated } from 'vue'
+import { onBeforeUpdate, onUpdated } from 'vue'
 
 export default {
   setup() {
     let itemRefs = []
     const setItemRef = el => {
-      itemRefs.push(el)
+      if (el) {
+        itemRefs.push(el)
+      }
     }
     onBeforeUpdate(() => {
       itemRefs = []
@@ -55,7 +59,6 @@ export default {
       console.log(itemRefs)
     })
     return {
-      itemRefs,
       setItemRef
     }
   }


### PR DESCRIPTION
ref. #202

Migration > Array Refs を本家の master に追従しました。

ファイルの更新履歴
https://github.com/vuejs/docs-next/commits/master/src/guide/migration/array-refs.md

前回からの差分
https://github.com/vuejs/docs-next/commit/24c809e57b0019a699483a56c3ad6338b0618cbe

close #202
