### PR TITLE
Migration > Attribute Coercion の翻訳を追従

### DIFF
--- a/src/guide/migration/attribute-coercion.md
+++ b/src/guide/migration/attribute-coercion.md
@@ -20,15 +20,15 @@ badges:
 
 ## 2.x での構文
 
-2.x では、`v-bind`の値を強制するために以下のような戦略がありました:
+2.x では、`v-bind` の値を強制するために以下のような戦略がありました:
 
 - いくつかの属性/要素のペアでは、Vue は常に対応する IDL 属性（プロパティ）を使用します。: [`<input>`、`<select>`、`<progress>`における`value`など](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/util/attrs.js#L11-L18)
 
-- 「[ブール属性](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/util/attrs.js#L33-L40)」と[xlinks](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/util/attrs.js#L44-L46)については、Vue はそれらが"falsy"([`undefined`、`null`、`false`](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/util/attrs.js#L52-L54))の場合には削除し、それ以外の場合には追加します ([ここ](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/runtime/modules/attrs.js#L66-L77)や[こちら](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/runtime/modules/attrs.js#L81-L85)を見てください)。
+- 「[ブール属性](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/util/attrs.js#L33-L40)」と [xlinks](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/util/attrs.js#L44-L46) については、Vue はそれらが "falsy" ([`undefined`、`null`、`false`](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/util/attrs.js#L52-L54)) の場合には削除し、それ以外の場合には追加します ([ここ](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/runtime/modules/attrs.js#L66-L77)や[こちら](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/runtime/modules/attrs.js#L81-L85)を見てください)。
 
-- 「[列挙された属性](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/util/attrs.js#L20)」(現在は`contenteditable`、`draggable`、`spellcheck`)については、Vue はそれらを[強制的に](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/util/attrs.js#L24-L31)文字列にしようとします ([vuejs/vue#9397](https://github.com/vuejs/vue/issues/9397)を修正するために、`contenteditable`については今のところ特別な扱いをしています)。
+- 「[列挙された属性](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/util/attrs.js#L20)」(現在は `contenteditable`、`draggable`、`spellcheck`)については、Vue はそれらを[強制的に](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/util/attrs.js#L24-L31)文字列にしようとします ([vuejs/vue#9397](https://github.com/vuejs/vue/issues/9397)を修正するために、`contenteditable` については今のところ特別な扱いをしています)。
 
-- 他の属性については、"falsy"な値(`undefined`, `null`, or `false`)は削除し、他の値はそのまま設定します([こちら](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/runtime/modules/attrs.js#L92-L113)を見てください)。
+- 他の属性については、"falsy" な値(`undefined`, `null`, or `false`)は削除し、他の値はそのまま設定します([こちら](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/runtime/modules/attrs.js#L92-L113)を見てください)。
 
 次の表では、Vue が「列挙された属性」を通常の非ブール属性とは異なる方法で強制する方法を説明しています:
 
@@ -43,18 +43,18 @@ badges:
 | `attr="foo"`        | `foo="foo"`                 | `draggable="true"`                    |
 | `attr`              | `foo=""`                    | `draggable="true"`                    |
 
-上の表からわかるように、現在の実装では`true`を`'true'`に強制していますが、`false`の場合は属性を削除しています。これはまた、`aria-selected`や`aria-hidden`といった`aria-*`属性のような非常に一般的なユースケースでも、ユーザーが手動でブール値を文字列に強制する必要があるなど、一貫性に欠けていました。
+上の表からわかるように、現在の実装では `true` を `'true'` に強制していますが、`false` の場合は属性を削除しています。これはまた、`aria-selected` や `aria-hidden` といった `aria-*` 属性のような非常に一般的なユースケースでも、ユーザーが手動でブール値を文字列に強制する必要があるなど、一貫性に欠けていました。
 
 ## 3.x での構文
 
 この「列挙された属性」という内部概念を捨てて、通常の非ブール HTML 属性として扱うつもりです。
 
 - これは、通常の非ブール属性と「列挙された属性」の間の矛盾を解決します。
-- また、`'true'`や`'false'`以外の値や、`contenteditable` のような属性には、これから定義されるキーワードを使用することも可能になります。
+- また、`'true'` や `'false'` 以外の値や、`contenteditable` のような属性には、これから定義されるキーワードを使用することも可能になります。
 
-非ブール属性については、Vue は`false`であれば削除はせず、代わりに`'false'`に強制します。
+非ブール属性については、Vue は `false` であれば削除はせず、代わりに `'false'` に強制します。
 
-- これにより、`true`と`false`の間の矛盾が解消され、`aria-*`属性の出力が容易になります。
+- これにより、`true` と `false` の間の矛盾が解消され、`aria-*` 属性の出力が容易になります。
 
 新しい振る舞いについては、以下の表を参照してください:
 
@@ -77,7 +77,7 @@ badges:
 
 ### 列挙された属性
 
-列挙された属性が存在しない場合や`attr="false"`が存在しない場合に、以下のように異なる IDL 属性値(実際の状態を反映した値)が生成されることがあります:
+列挙された属性が存在しない場合や `attr="false"` が存在しない場合に、以下のように異なる IDL 属性値(実際の状態を反映した値)が生成されることがあります:
 
 | 列挙された属性の不在 | IDL 属性と値                         |
 | -------------------- | ------------------------------------ |
@@ -85,9 +85,9 @@ badges:
 | `draggable`          | `draggable` &rarr; `false`           |
 | `spellcheck`         | `spellcheck` &rarr; `true`           |
 
-これまでの振る舞いを維持するために、また、`false`を`'false'`に強制するために、3.x Vue の開発者は`contenteditable`と`spellcheck`に対して`v-bind`式を`false`または`'false'`に解決する必要があります。
+これまでの振る舞いを維持するために、また、`false` を `'false'` に強制するために、3.x Vue の開発者は `contenteditable` と `spellcheck` に対して `v-bind` 式を `false` または `'false'` に解決する必要があります。
 
-2.x では、列挙された属性に対して無効な値を`'true'`に強制的に設定していました。これは通常意図していなかったもので、大規模に利用される可能性は低いと思われます。3.x では、`true`または`'true'`を明示的に指定する必要があります。
+2.x では、列挙された属性に対して無効な値を `'true'` に強制的に設定していました。これは通常意図していなかったもので、大規模に利用される可能性は低いと思われます。3.x では、`true` または `'true'` を明示的に指定する必要があります。
 
 ### 属性を削除する代わりに `false` を `'false'` に強制する
 

--- a/src/guide/migration/attribute-coercion.md
+++ b/src/guide/migration/attribute-coercion.md
@@ -3,7 +3,7 @@ badges:
   - breaking
 ---
 
-# 属性強制の振舞い <MigrationBadges :badges="$frontmatter.badges" />
+# 属性強制の振る舞い <MigrationBadges :badges="$frontmatter.badges" />
 
 ::: info Info
 これはローレベルな内部 API の変更であり、ほとんどの開発者には影響しません。
@@ -56,7 +56,7 @@ badges:
 
 - これにより、`true`と`false`の間の矛盾が解消され、`aria-*`属性の出力が容易になります。
 
-新しい振舞いについては、以下の表を参照してください:
+新しい振る舞いについては、以下の表を参照してください:
 
 | バインディング式    | `foo` <sup>通常の属性</sup> | `draggable` <sup>列挙された属性</sup> |
 | ------------------- | --------------------------- | ------------------------------------- |
@@ -85,7 +85,7 @@ badges:
 | `draggable`          | `draggable` &rarr; `false`           |
 | `spellcheck`         | `spellcheck` &rarr; `true`           |
 
-これまでの振舞いを維持するために、また、`false`を`'false'`に強制するために、3.x Vue の開発者は`contenteditable`と`spellcheck`に対して`v-bind`式を`false`または`'false'`に解決する必要があります。
+これまでの振る舞いを維持するために、また、`false`を`'false'`に強制するために、3.x Vue の開発者は`contenteditable`と`spellcheck`に対して`v-bind`式を`false`または`'false'`に解決する必要があります。
 
 2.x では、列挙された属性に対して無効な値を`'true'`に強制的に設定していました。これは通常意図していなかったもので、大規模に利用される可能性は低いと思われます。3.x では、`true`または`'true'`を明示的に指定する必要があります。
 
@@ -93,7 +93,7 @@ badges:
 
 3.x では、明示的に属性を削除するには `null` または `undefined` を使用しなければなりません。
 
-### 2.x と 3.x 間の振舞いの比較
+### 2.x と 3.x 間の振る舞いの比較
 
 <table>
   <thead>


### PR DESCRIPTION
## Description of Problem

Migration > Attribute Coercion を master に追従しました。
ref. #204 

## Proposed Solution

ファイルの更新履歴
https://github.com/vuejs/docs-next/commits/master/src/guide/migration/attribute-coercion.md

前回からの差分
https://github.com/vuejs/docs-next/commit/639940b6154e318b0b26fd4a394defaa82eb45ba#diff-b479f35a5791f7d2ecdce48c7b3e621263cb53117bcf03bc2e7cf9a020974f49

表のマークダウンをフォーマットしたのみなので、翻訳の差分はありませんでした。

[日本語翻訳ガイド](https://github.com/vuejs-jp/ja.vuejs.org/blob/lang-ja/.github/CONTRIBUTING.md)にあわせて、2点修正しました。

## Additional Information

振舞い -> 振る舞い

<details>
<summary>送り仮名の検索結果</summary>

```
❯ rg '振る舞い'
src/api/application-api.md
175:  アプリケーションスコープ全体に mixin を適用します。一度登録された場合、該当のアプリケーション内の任意のコンポーネントのテンプレートで利用することができます。プラグイン作者がコンポーネントにカスタムの振る舞いを注入するために使用することができます。**アプリケーションコードでは推奨されません。**.

src/style-guide/README.md
133:サブツリーの内部コンポーネントの状態を維持するために、コンポーネントでの `v-for` には _常に_ `key` を付ける必要があります。ただし要素の場合であっても、アニメーションでの[オブジェクトの一貫性](https://bost.ocks.org/mike/constancy/)のように、予測可能な振る舞いを維持することをお勧めします。

src/guide/template-syntax.md
147:`v-` 接頭辞は、テンプレート内の Vue 独自の属性を識別するための目印となっています。これは既存のマークアップに対して、Vue.js を利用して動的な振る舞いを適用する場合に便利ですが、頻繁に利用されるディレクティブに対しては冗長に感じることがあるでしょう。同じく全てのテンプレートを Vue で管理して[シングルページアプリケーション](https://en.wikipedia.org/wiki/Single-page_application)を作る場合、`v-` 接頭辞を付ける必要性は低いものになるでしょう。そのため、 Vue は2つの最もよく使われるディレクティブ `v-bind` と `v-on` に対して特別な省略記法を提供しています:

src/guide/migration/global-api.md
8:Vue 2.x では、グローバルに Vue の振る舞いを変更するグローバル API や設定が多数ありました。例えば、グローバルコンポーネントを作る際には、 以下のような `Vue.component` API を使用していました:
68:アプリケーションインスタンスは、現在のグローバル API のサブセットを公開します。おおまかには、_Vue の振る舞いをグローバルに変更する全ての API は、アプリケーションインスタンスに移されます_ 。こちらは、現在のグローバル API とインスタンス API との対応表です:
80:グローバルに振る舞いを変更しないその他のグローバル API は [グローバル API の Treeshaking](./global-api-treeshaking.html) にあるように、名前付きエクスポートになりました。

src/guide/reactivity-computed-watchers.md
160:`onTrack` および `onTrigger` オプションは、ウォッチャの振る舞いのデバッグに利用できます。
223:### `watchEffect` との振る舞いの共有

src/guide/migration/v-bind.md
2:title: v-bind マージの振る舞い
30:Vue 3.x では、要素に `v-bind="object"` 構文と同一の個別のプロパティの両方が定義されている場合、バインディングの宣言されている順番がそれらをどのようにマージするかを決定します。言い換えると、開発者は個別のプロパティが `object` で定義されているものを常に上書きするのだと決め込むのではなく、希望するマージの振る舞いをコントロールできるようになります。

src/guide/reactivity-fundamentals.md
73:`ref` がリアクティブオブジェクトのプロパティとしてアクセスまたは更新される際に、自動的に内部の値にアンラップされて通常のプロパティのように振る舞います:

src/guide/custom-directive.md
185:前回の例では、`mounted` と `updated` に同じ振る舞いを欲しかったでしょう。しかし、その他のフック関数を気にしてはいけません。ディレクティブにコールバックを渡すことで実現できます:

src/guide/transitions-enterleave.md
496:それは、"on" ボタンと "off" ボタン間でトランジションを行うとき、片方のボタンがトランジションアウトして、別の片方がトランジションインするとき、両方のボタンが描画されてしまうことです。これは、`<transition>` のデフォルトの振る舞いです - entering と leaving は同時に起きます。

src/guide/composition-api-setup.md
151:**`setup()` 内では、`this` は現在のアクティブなインスタンスへの参照にはなりません。** `setup()` は他のコンポーネントオプションが解決される前に呼び出されるので、`setup()` 内の`this` は他のオプション内の `this`とは全く異なる振る舞いをします。 これは、`setup()` を他のオプション API と一緒に使った場合に混乱を引き起こす可能性があります。

src/guide/introduction.md
98:ここで新しい属性が出てきました。`v-bind` 属性は**ディレクティブ**と呼ばれます。ディレクティブは Vue によって提供された特別な属性であることを示すために `v-` 接頭辞がついています。これはあなたの推測通り、レンダリングされた DOM に特定のリアクティブな振る舞いを与えます。ここで宣言されているのは、「_この要素の `title` 属性を、現在アクティブなインスタンスにおける `message` プロパティの最新状態に維持する_」ということになります。

src/guide/component-provide-inject.md
100:前述の例では、リスト `todos` を変更しても、その変更は注入された `todoLength` には反映されません。これは、`provide/inject` の束縛（ binding ）がデフォルトでリアクティブ _でない_ ことが原因です。`ref` で定義されたプロパティや `reactive` で作成されたオブジェクトを `provide` に渡すことにより、この振る舞いを変更することができます。この場合、祖先コンポーネントをリアクティブにするためには、コンポジション API の `computed` で定義したプロパティを `todoLength` を割り当てる必要があります。

src/guide/composition-api-introduction.md
119:    getUserRepositories // 返される関数は methods と同様の振る舞いをします
```

</details>

アルファベット両端の半角スペース

半角スペース有無のゆれを「[半角スペースでアルファベット両端を入れて読みやすく！](https://github.com/vuejs-jp/ja.vuejs.org/blob/lang-ja/.github/CONTRIBUTING.md#%E5%8D%8A%E8%A7%92%E3%82%B9%E3%83%9A%E3%83%BC%E3%82%B9%E3%81%A7%E3%82%A2%E3%83%AB%E3%83%95%E3%82%A1%E3%83%99%E3%83%83%E3%83%88%E4%B8%A1%E7%AB%AF%E3%82%92%E5%85%A5%E3%82%8C%E3%81%A6%E8%AA%AD%E3%81%BF%E3%82%84%E3%81%99%E3%81%8F)」にノーマライズ

close #204  
