### PR TITLE
Textlint エラーの修正

### DIFF
--- a/src/guide/migration/attrs-includes-class-style.md
+++ b/src/guide/migration/attrs-includes-class-style.md
@@ -38,7 +38,7 @@ export default {
 <my-component id="my-id" class="my-class"></my-component>
 ```
 
-...以下のHTMLが生成されます:
+...以下の HTML が生成されます:
 
 ```html
 <label class="my-class">
@@ -48,7 +48,7 @@ export default {
 
 ## 3.x の挙動
 
-`$attrs` には、すべての属性が含まれているので、すべての属性を別の要素に適用することが簡単にできます。先ほどの例は、次のHTMLが生成されます:
+`$attrs` には、すべての属性が含まれているので、すべての属性を別の要素に適用することが簡単にできます。先ほどの例は、次の HTML が生成されます:
 
 ```html
 <label>


### PR DESCRIPTION
## Description of Problem

Textlint のエラーが発生していた箇所を修正しました。

## Proposed Solution

「HTML」の前後にスペースを追加しました。

```
$ node -e "var shell=require('shelljs');var files=shell.find(['./src/**/*.md']).filter(function(file){return !file.endsWith('/guide/team.md')}).join(' ');if(shell.exec('textlint --rulesdir ./node_modules/textlint-checker-for-vuejs-jp-docs/rules/textlint-rule-vue-jp-docs -f pretty-error '+files).code!==0){shell.exit(1)};"
textlint-rule-vue-jp-docs: 半角と全角の間は一文字あける :  [Lが] ... ...以下のHTMLが生成されます:
/home/runner/work/ja.vuejs.org/ja.vuejs.org/src/guide/migration/attrs-includes-class-style.md:41:1
        v
    40. 
    41. ...以下のHTMLが生成されます:
    42. 
        ^

textlint-rule-vue-jp-docs: 半角と全角の間は一文字あける :  [Lが] ...  には、すべての属性が含まれているので、すべての属性を別の要素に適用することが簡単にできます。先ほどの例は、次のHTMLが生成されます:
/home/runner/work/ja.vuejs.org/ja.vuejs.org/src/guide/migration/attrs-includes-class-style.md:51:9
                v
    50. 
    51. `$attrs` には、すべての属性が含まれているので、すべての属性を別の要素に適用することが簡単にできます。先ほどの例は、次のHTMLが生成されます:
    52. 
                ^

✖ 2 problems (2 errors, 0 warnings)
```

## Additional Information
