### PR TITLE
Fix on guide/composition-api-setup.md

### DIFF
--- a/src/guide/composition-api-setup.md
+++ b/src/guide/composition-api-setup.md
@@ -48,7 +48,7 @@ setup(props) {
 }
 ```
 
-`title` オプションのプロパティである場合、 `props` から抜けている可能性があります。その場合、 `toRefs` では `title` の ref はつくられません。代わりに `toRef` を使う必要があります:
+`title` が省略可能なプロパティである場合、 `props` から抜けている可能性があります。その場合、 `toRefs` では `title` の ref はつくられません。代わりに `toRef` を使う必要があります:
 
 ```js
 // MyBook.vue


### PR DESCRIPTION
こんにちは✋ このドキュメントは VueJS の勉強にとても良く、熱心に読ませていただいています。
今回は和訳の改善提案をさせてください。

## Description of Problem

現状、以下の英文（[ソース](https://github.com/vuejs-jp/ja.vuejs.org/blob/master/src/guide/composition-api-setup.md#props)）に対し:

> If `title` is an optional prop, it could be missing from `props`. In that case, `toRefs` won't create a ref for `title`. Instead you'd need to use `toRef`:

以下の和訳（[ソース](https://github.com/vuejs-jp/ja.vuejs.org/blob/lang-ja/src/guide/composition-api-setup.md#%E3%83%97%E3%83%AD%E3%83%91%E3%83%86%E3%82%A3)）が割り当てられています:

> `title` オプションのプロパティである場合、 `props` から抜けている可能性があります。その場合、 `toRefs` では `title` の ref はつくられません。代わりに `toRef` を使う必要があります:

このドキュメントでは、 `setup` や `data` のような API を「オプション」と呼ぶことがあるのも相まって、「オプション」という訳だと理解の妨げになるように感じました。

## Proposed Solution
`optional` を「省略可能な」と和訳することを提案させてください。
或いは単純に「オプショナルな」という訳も良いかもしれません。

もし、「オプション」の訳のままにしたい場合でも「 `title` がオプションのプロパティである場合...」という具合に助詞があるべきだと考えています。

## Additional Information
- 例えば、以下の React のドキュメントでは「省略可能な」という訳が当てられています。
  - 英訳: https://github.com/reactjs/reactjs.org/blob/master/content/docs/addons-test-utils.md#other-utilities-other-utilities
  - 和訳: https://github.com/reactjs/ja.reactjs.org/blob/master/content/docs/addons-test-utils.md#%E3%81%9D%E3%81%AE%E4%BB%96%E3%81%AE%E3%83%A6%E3%83%BC%E3%83%86%E3%82%A3%E3%83%AA%E3%83%86%E3%82%A3-other-utilities
- 一方で、同じ React のドキュメントですが「オプションで」という訳が当てられる場面もあります。
  - 英訳: https://github.com/reactjs/reactjs.org/blob/master/content/docs/concurrent-mode-reference.md#usedeferredvalue-usedeferredvalue
  - 和訳: https://github.com/reactjs/ja.reactjs.org/blob/master/content/docs/concurrent-mode-reference.md#usedeferredvalue-usedeferredvalue