### PR TITLE
ソフトウエア用語の訳

### DIFF
--- a/src/api/composition-api.md
+++ b/src/api/composition-api.md
@@ -191,7 +191,7 @@ const MyComponent = {
   ): T
   ```
 
-  Vue は `Symbol` を拡張したジェネリック型の `InjectionKey` インターフェイスを提供しています。これはプロバイダとコンシューマの間で注入された値の型を同期するために使用できます:
+  Vue は `Symbol` を拡張したジェネリック型の `InjectionKey` インターフェイスを提供しています。これは Provider（プロバイダ）と Consumer（コンシューマ）の間で注入された値の型を同期するために使用できます:
 
   ```ts
   import { InjectionKey, provide, inject } from 'vue'


### PR DESCRIPTION
## Description of Problem

https://github.com/vuejs-jp/ja.vuejs.org/pull/557#discussion_r754863593
こちらのレビューでもあったように、
ソフトウエア用語に関しては原文ママ、カッコ書きで訳注というフォーマットに修正します。

## Proposed Solution

他の同じような箇所と統一感あるか調べて、同じように修正します。

```
src/guide/ssr/structure.md
82:基本的な考え方は、 webpack でアプリケーションをクライアントとサーバの両方にバンドルすることです。サーバ用のバンドルは、サーバ上で静的な HTML をレンダリングするために使われ、クライアント用のバンドルは、静的なマークアップを Hydrate（ハイドレート）するためにブラウザに送信されます。

src/cookbook/debugging-in-vscode.md
93:もっと複雑なデバッグの方法もあります。最も一般的で単純な方法は、優れた Vue.js devtools [Chrome 向け](https://chrome.google.com/webstore/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd) と [Firefox 向け](https://addons.mozilla.org/en-US/firefox/addon/vue-js-devtools/) を使うことです。Devtools を使うことのいくつかの利点は、データのプロパティを Live Edit（ライブエディット）して、その変更がすぐに反映されることです。その他の主な利点は、Vuex のタイムトラベルデバッグが可能になることです。

src/guide/ssr/introduction.md
9:サーバサイドレンダリングした Vue.js アプリケーションは、「Isomorphic（アイソモルフィック）」とか「Universal（ユニバーサル）」と考えることもできます。これはつまり、アプリケーションのコードの大部分がサーバ **と** クライアントの両方で実行されるということを意味します。

src/guide/render-function.md
556:`<keep-alive>`、`<transition>`、`<transition-group>`、 `<teleport>` などの [組み込みコンポーネント](/api/built-in-components.html) はデフォルトではグローバルに登録されません。これによりバンドラーが Tree Shaking（ツリーシェイキング）を行い、コンポーネントが使われている場合にだけビルドに含まれるようになります。しかし、これは `resolveComponent` や `resolveDynamicComponent` を使ってアクセスできないということです。

src/guide/migration/events-api.md
102:* `provide`/`inject` はコンポーネント間の距離が離れている通信にも使えます。プロパティを必要としないコンポーネントを何階層にもわたって、プロパティを渡す必要のある「Prop Drilling（プロパティのバケツリレーのこと）」を回避するのに役立ちます。

src/guide/ssr/universal.md
1:# Universal（ユニバーサルな）コードを書く
```

## Additional Information

https://github.com/vuejs-jp/ja.vuejs.org/wiki/%E3%81%8B%E3%81%A3%E3%81%93
そういえば自分でルールを書いていたことを思い出しました。
