### PR TITLE
Update Devtools links in installation.md

### DIFF
--- a/src/guide/installation.md
+++ b/src/guide/installation.md
@@ -23,11 +23,11 @@ Vue.js をプロジェクトに追加するには主に 4 つの方法があり�
 
 Vue を使用する場合は、ブラウザに [Vue Devtools](https://github.com/vuejs/vue-devtools#vue-devtools) をインストールすることをおすすめします。これにより、Vue アプリケーションをよりユーザーフレンドリーなインターフェースで調査、デバッグすることが可能になります。
 
-[Chrome 拡張版を入手](https://chrome.google.com/webstore/detail/vuejs-devtools/ljjemllljcmogpfapbkkighbhhppjdbg)
+[Chrome 拡張版を入手](https://chrome.google.com/webstore/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd)
 
 [Firefox アドオン版を入手](https://addons.mozilla.org/en-US/firefox/addon/vue-js-devtools/)
 
-[スタンドアロンの Electron アプリケーション版を入手](https://github.com/vuejs/vue-devtools/blob/dev/packages/shell-electron/README.md)
+[スタンドアロンの Electron アプリケーション版を入手](https://devtools.vuejs.org/guide/installation.html#standalone)
 
 ## CDN
 


### PR DESCRIPTION
## Description of Problem
Devtools description is outdated for original document

## Proposed Solution
* Update link to devtools for Chrome
* Update link to Standalone Devtools

## Additional Information
Original docs : [tooling.md](https://github.com/vuejs/docs/blob/main/src/guide/scaling-up/tooling.md#browser-devtools)
Related commit in original docs : [f8a90e9](https://github.com/vuejs/docs/commit/f8a90e9f0a004d84b4c40d273e7ea151f64d42a5)